### PR TITLE
Accept custom column value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ To use this lib, first you will have to install it:
 ```
 npm i knex-on-duplicate-update --save
 ```
+or
+```
+yarn add knex-on-duplicate-update
+```
 
 Then, add the following lines to your Knex set up:
 
@@ -25,7 +29,7 @@ attachOnDuplicateUpdate();
 ## Function definition
 
 ```javascript
-onDuplicateUpdate(...columns: string[]): Knex.QueryBuilder
+onDuplicateUpdate(...columns: Array<{[key: string]: string} | string>): Knex.QueryBuilder
 ```
 
 ## How to use
@@ -36,5 +40,13 @@ await knex.insert({id: 1, name: 'John', email: 'john@mail.com'})
     .into('persons')
     .onDuplicateUpdate('name', 'email');
 ```
+
+Setting a fallback value for a column
+```javascript
+await knex.insert({id: 1, name: 'John', email: 'john@mail.com'})
+    .into('persons')
+    .onDuplicateUpdate('name', {email: 'john-exists@mail.com'});
+```
+
 
 This lib got inspiration from [`knex-paginator`](https://github.com/cannblw/knex-paginator).

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -38,6 +38,10 @@ describe('onDuplicateUpdate', () => {
       expect(() => db.insert({ id: 1, name: 'test' }).into('persons').onDuplicateUpdate())
         .toThrowError('onDuplicateUpdate error: please specify at least one column name.');
     });
+    it('should throw if no columns are not string or object', () => {
+      expect(() => db.insert({ id: 1, name: 'test' }).into('persons').onDuplicateUpdate(false))
+        .toThrowError('onDuplicateUpdate error: expected column name to be string or object.');
+    });
   });
 
   describe('behaviour', () => {
@@ -67,6 +71,21 @@ describe('onDuplicateUpdate', () => {
       const person = await getById(id);
 
       expect(person).toEqual(expect.objectContaining({ name: 'test5', email: '5@5.com' }));
+    });
+
+    it('should allow specifying a value for a column when updating multiple', async () => {
+      const id = 5;
+      await db.insert({ id, name: 'test6', email: '6@6.com' }).into('persons');
+      await db.insert({
+        id,
+        name: 'test6',
+        email: '6@6.com'
+      }).into('persons').onDuplicateUpdate('name', {'email': 'updated-email'});
+      const person = await getById(id);
+      expect(person).toEqual(expect.objectContaining({
+        name: 'test6',
+        email: 'updated-email',
+      }));
     });
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,11 +10,32 @@ module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
       throw new Error('onDuplicateUpdate error: please specify at least one column name.');
     }
 
-    const columnsPlaceHolders = columns.map(() => `??=Values(??)`).join(', ');
+    const columnsPlaceHolders = columns.map((column) => {
+      if (typeof column === 'string'){
+        return `??=Values(??)`
+      }
+      if (column && typeof column === 'object'){
+        return Object.keys(column).map(() => `??=?`).join(', ')
+      }
+      throw new Error('onDuplicateUpdate error: expected column name to be string or object.');
+    }).join(', ');
+
+    const binds = columns.reduce((bindings, column) => {
+      if (typeof column === 'string'){
+        return bindings.concat([column, column])
+      }
+      if (column && typeof column === 'object'){
+        const objectColumns = Object.keys(column).map((col) => {
+          return [col, column[col]]
+        })
+        return bindings.concat(...objectColumns)
+      }
+      throw new Error('onDuplicateUpdate error: expected column name to be string or object.');
+    }, [])
 
     return this.client.raw(
       `${this.toString()} on duplicate key update ${columnsPlaceHolders}`,
-      columns.reduce((bindings, column) => bindings.concat([column, column]), [])
+      binds
     );
   };
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,7 +2,7 @@ import { QueryBuilder as KnexQB } from 'knex';
 
 declare module 'knex' {
   interface QueryBuilder {
-    onDuplicateUpdate(...columnNames: string[]): KnexQB;
+    onDuplicateUpdate(...columnNames: Array<{[key: string]: string} | string>): KnexQB;
   }
 }
 


### PR DESCRIPTION
Regarding https://github.com/felixmosh/knex-on-duplicate-update/issues/4

I was able to do it without breaking the API format.

This change enables specifying a custom column value for when the inserted row already exists.
This is going to be specially useful for me when managing row state:
I'll be inserting new rows with the state set as `new` BUT update existing ones to state `updated`.

```
    .insert([{
      title: 'someTitle',
      description: 'some Description',
      state: 'new'
    }])
    .into('someTable')
    .onDuplicateUpdate('title', 'description', ['state', 'updated'])
```

If you believe this can be merged, I can spend another moment updating docs and the types