### PR TITLE
Handle unescaped ? when calling toString() on query

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -112,7 +112,7 @@ describe('onDuplicateUpdate', () => {
 
     it('should correctly escape field with ? character', async () => {
       await db
-        .insert({ id: 7, name: '?' })
+        .insert({ id: 7, name: 'other value' })
         .into('persons');
       await db
         .insert({ id: 7, name: '?' })

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -109,5 +109,18 @@ describe('onDuplicateUpdate', () => {
         email: 'updated-email',
       }));
     });
+
+    it('should correctly escape field with ? character', async () => {
+      await db
+        .insert({ id: 7, name: '?' })
+        .into('persons');
+      await db
+        .insert({ id: 7, name: '?' })
+        .into('persons')
+        .onDuplicateUpdate('name');
+      const person = await getById(7);
+
+      expect(person.name).toBe('?');
+    });
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,9 @@ module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
 
       return result;
     }, { placeholders: [], bindings: [] });
-
+    const escapeKnexString = input => input.split('?').join('\\?');
     return this.client.raw(
-      `${this.toString()} on duplicate key update ${placeholders.join(', ')}`,
+      `${escapeKnexString(this.toString())} on duplicate key update ${placeholders.join(', ')}`,
       bindings
     );
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
 
       return result;
     }, { placeholders: [], bindings: [] });
-    const escapeKnexString = input => input.split('?').join('\\?');
+    const escapeKnexString = input => input.replace(/\?/g, '\\?');
     return this.client.raw(
       `${escapeKnexString(this.toString())} on duplicate key update ${placeholders.join(', ')}`,
       bindings


### PR DESCRIPTION
I noticed that when a field in the initial query contains a question mark that the `knex.raw` statement treats that as an indication that we should be subbing a value in.  This should ensure that we correctly escape any `?`'s in the future.  Let me know what you think!