### PR TITLE
[SECURITY] Update query building to join queries in a more secure way

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,9 +28,16 @@ module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
       return result;
     }, { placeholders: [], bindings: [] });
 
+    const {
+      sql: originalSQL,
+      bindings: originalBindings,
+    } = this.toSQL();
+
+    const newBindings = [ ...originalBindings, ...bindings ];
+
     return this.client.raw(
-      `${escapeKnexBinding(this.toString())} on duplicate key update ${placeholders.join(', ')}`,
-      bindings
+      `${originalSQL} on duplicate key update ${placeholders.join(', ')}`,
+      newBindings,
     );
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 const KnexQueryBuilder = require('knex/lib/query/builder');
 
-const escapeKnexBinding = input => input.replace(/\?/g, '\\?');
-
 module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
   KnexQueryBuilder.prototype.onDuplicateUpdate = function (...columns) {
     if (this._method !== 'insert') {


### PR DESCRIPTION
Knex `.toString()` is open to SQL injection attacks in certain situations. This was mostly mitigated with the `escapeKnexBinding` function, however it is better to let the DB engine handle this itself. Most DBs will pass the bindings separately as bound parameters and the server itself is responsible for interpolating them. This is much more secure than attempting to escape values on the client.

Relevant Conversation: https://github.com/knex/knex/issues/5882