### PR TITLE
Fix: throw if insert statement is empty

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -42,6 +42,10 @@ describe('onDuplicateUpdate', () => {
       expect(() => db.insert({ id: 1, name: 'test' }).into('persons').onDuplicateUpdate(false))
         .toThrowError('onDuplicateUpdate error: expected column name to be string or object.');
     });
+    it('should throw if insert is empty array', () => {
+      expect(() => db.insert([]).into('persons').onDuplicateUpdate('whatever'))
+        .toThrowError('onDuplicateUpdate error: empty insert statement.');
+    });
   });
 
   describe('behaviour', () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ module.exports.attachOnDuplicateUpdate = function attachOnDuplicateUpdate() {
       bindings: originalBindings,
     } = this.toSQL();
 
+    if (!originalBindings.length) {
+      throw new Error('onDuplicateUpdate error: empty insert statement.')
+    }
+
     const newBindings = [...originalBindings, ...bindings];
 
     return this.client.raw(


### PR DESCRIPTION
This keeps consistency with knex own implementation of throwing when performing an empty array insert.
Currently, an empty [] insert is generating a broken sql query with just the "on duplicate update...." part. 
